### PR TITLE
feat: implement discovery feed ranked results (issue #27)

### DIFF
--- a/.claude/skills/add-feature.md
+++ b/.claude/skills/add-feature.md
@@ -1,0 +1,91 @@
+---
+name: add-feature
+description: Implement a new Pair app feature using TDD, enforcing dual-consent, tag normalization, connection state machine, and all project business rules.
+version: 2
+---
+
+Implement a new feature for the Pair app. Follows TDD and enforces all Pair-specific business rules before finishing.
+
+## Arguments
+
+`$ARGUMENTS` — a user story ID from the PRD (e.g. `US-06`) or a short description of the feature.
+
+## Step 1 — Extract requirements
+
+Read `docs/pair-prd.md`. Find every functional requirement (FR-*) and user story (US-*) related to `$ARGUMENTS`. Note:
+- Which layer owns each rule (backend only vs. frontend only vs. shared)
+- Any state transitions involved (`INTEREST_PENDING → INTEREST_ALIGNED → REQUEST_PENDING → CONNECTED → DECLINED`)
+- Whether dual-consent is in scope
+
+## Step 2 — Understand existing code
+
+Read the relevant files before writing anything:
+- `client/src/pages/` and `client/src/components/` for frontend context
+- `server/src/routes/` and `server/src/services/` for backend context
+- `shared/` for existing shared types
+
+Check if a similar pattern already exists — prefer extending it over creating a new abstraction.
+
+## Step 3 — Write failing tests (TDD red phase)
+
+- Frontend: tests in `*.test.tsx` using Vitest + React Testing Library
+- Backend: tests in `*.test.ts` using Vitest; hit real Supabase test instance (no mocks on DB)
+- E2E critical path: add a Playwright test in `e2e/` if this touches onboarding, partner linking, discovery, connection request, or chat
+- Run once to confirm tests fail:
+  ```bash
+  npm run test
+  ```
+
+## Step 4 — Implement the feature (TDD green phase)
+
+Write the minimum code to make tests pass. Apply these Pair-specific rules as you implement:
+
+### Dual-consent (FR-CONN-03)
+Connection state transitions MUST live in `server/src/services/`, not in route handlers or client code.
+
+### Duplicate-request guard (FR-CONN-09)
+Before inserting a `connection_requests` row, query for an existing request between the two couples in **any direction** and **any status**. If one exists, surface it instead of inserting.
+
+### Tag normalization (FR-TAG-03)
+All tags must be `.toLowerCase().trim()` before insert. Use the shared `normalizeTag` util in `shared/`. Do not re-implement inline.
+
+### Partner privacy (FR-CONN-08)
+If surfacing a DECLINED status to couple 1, never expose which partner of couple 2 declined. Return only the status.
+
+### Service role key
+The Supabase service role key MUST only appear in `server/` environment variables. Never import it in `client/`.
+
+### TypeScript
+- Strict mode — no `any`
+- Shared types (couple, connection_request, tag) belong in `shared/`
+- Named exports for components/utils; default exports for page components only
+
+## Step 5 — Run all tests
+
+```bash
+npm run test
+```
+
+All tests must pass. Fix any failures before proceeding.
+
+## Step 6 — Self-check against business rules
+
+Before reporting done, verify each item:
+
+- [ ] Connection state transitions are only in `server/src/services/`
+- [ ] No direct Supabase state mutations in client code (all go through Express API)
+- [ ] Duplicate-request check present before any `connection_requests` insert
+- [ ] Tags normalized (lowercase + trim) at service layer
+- [ ] Incomplete couples (one partner unregistered) excluded from discovery feed results
+- [ ] Partner privacy preserved — declining partner identity not exposed
+- [ ] Supabase service role key not referenced in `client/`
+- [ ] No `any` types introduced
+- [ ] Shared types added to `shared/` if new types were needed
+
+## Step 7 — Report
+
+Output:
+1. Which PRD requirements were addressed (FR-* / US-* IDs)
+2. Files created or modified
+3. Tests added
+4. Any business rule checks that required a code change

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,7 +5,7 @@ import RegisterPage from "./pages/RegisterPage";
 import AddInterestsPage from "./pages/AddInterestsPage";
 import ProfilePage from "./pages/ProfilePage";
 import CoupleProfilePage from "./pages/CoupleProfilePage";
-import DiscoverPage from "./pages/DiscoverPage";
+import DiscoveryPage from "./pages/DiscoveryPage";
 import InboundRequestsPage from "./pages/InboundRequestsPage";
 import PartnerInterestsPage from "./pages/PartnerInterestsPage";
 import ConnectionsPage from "./pages/ConnectionsPage";
@@ -35,7 +35,7 @@ export default function App() {
       {/* Auth + paired — app shell */}
       <Route element={<RequireAuthAndPaired />}>
         <Route element={<AppLayout />}>
-          <Route path="/" element={<DiscoverPage />} />
+          <Route path="/" element={<DiscoveryPage isLinked={true} />} />
           <Route path="/inbound-requests" element={<InboundRequestsPage />} />
           <Route path="/partner-interests" element={<PartnerInterestsPage />} />
           <Route path="/connections" element={<ConnectionsPage />} />

--- a/client/src/components/CoupleCard.tsx
+++ b/client/src/components/CoupleCard.tsx
@@ -1,5 +1,5 @@
 export interface Couple {
-  id: number;
+  id: string;
   names: string;
   initials1: string;
   initials2: string;
@@ -8,8 +8,6 @@ export interface Couple {
   matching: string[];
   description: string;
   location: string;
-  complete: boolean;
-  connected: boolean;
 }
 
 export function AvatarPair({

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -924,6 +924,8 @@ code {
 .pill--sm {
   font-size: 12px;
   padding: 2px 8px;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 /* Couple grid */
@@ -970,12 +972,14 @@ code {
   display: flex;
   align-items: center;
   gap: 12px;
+  min-width: 0;
 }
 
 .couple-names {
   font-size: 15px;
   font-weight: 500;
   color: #000;
+  min-width: 0;
 }
 
 /* Avatar pair */

--- a/client/src/pages/DiscoveryPage.test.tsx
+++ b/client/src/pages/DiscoveryPage.test.tsx
@@ -1,10 +1,73 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import DiscoveryPage from "./DiscoveryPage";
 
+vi.mock("../lib/api", () => ({
+  apiFetch: vi.fn(),
+}));
+
+const { apiFetch } = await import("../lib/api");
+const mockApiFetch = apiFetch as ReturnType<typeof vi.fn>;
+
+const FIXTURE = [
+  {
+    pair_id: "pair-1",
+    about_us: "Active couple who love hiking.",
+    location: "Denver, CO",
+    tags: ["hiking", "cycling", "films"],
+    matching_tags: ["hiking", "cycling"],
+    shared_count: 2,
+    partner1: {
+      display_name: "Morgan",
+      about_me: "I love the mountains.",
+      location: "Denver, CO",
+      tags: ["hiking", "cycling"],
+    },
+    partner2: {
+      display_name: "Casey",
+      about_me: "Film buff.",
+      location: "Denver, CO",
+      tags: ["films", "cycling"],
+    },
+  },
+  {
+    pair_id: "pair-2",
+    about_us: "Outdoor enthusiasts.",
+    location: "Portland, OR",
+    tags: ["board games", "cooking"],
+    matching_tags: ["cooking"],
+    shared_count: 1,
+    partner1: {
+      display_name: "Alex",
+      about_me: null,
+      location: null,
+      tags: ["board games"],
+    },
+    partner2: {
+      display_name: "Jordan",
+      about_me: null,
+      location: "Portland, OR",
+      tags: ["cooking"],
+    },
+  },
+];
+
+function mockSuccess(data = FIXTURE) {
+  mockApiFetch.mockResolvedValue({
+    ok: true,
+    json: async () => data,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("DiscoveryPage", () => {
-  it("renders the page heading", () => {
+  it("renders the page heading", async () => {
+    mockSuccess();
     render(
       <MemoryRouter>
         <DiscoveryPage isLinked={true} />
@@ -15,12 +78,18 @@ describe("DiscoveryPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("displays couples ranked by shared tag count descending", () => {
+  it("displays couples ranked by shared tag count descending", async () => {
+    mockSuccess();
     render(
       <MemoryRouter>
         <DiscoveryPage isLinked={true} />
       </MemoryRouter>,
     );
+
+    await waitFor(() =>
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
+    );
+
     const counts = screen
       .getAllByText(/in common/i)
       .map((el) => parseInt(el.textContent ?? "0"));
@@ -29,33 +98,48 @@ describe("DiscoveryPage", () => {
     }
   });
 
-  it("shows the shared tag count on each couple card", () => {
+  it("shows the shared tag count badge on each card", async () => {
+    mockSuccess();
     render(
       <MemoryRouter>
         <DiscoveryPage isLinked={true} />
       </MemoryRouter>,
     );
+
+    await waitFor(() =>
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
+    );
+
     const badges = screen.getAllByText(/in common/i);
     expect(badges.length).toBeGreaterThan(0);
   });
 
-  it("renders filter pills", () => {
+  it("renders filter pills derived from fetched tags", async () => {
+    mockSuccess();
     render(
       <MemoryRouter>
         <DiscoveryPage isLinked={true} />
       </MemoryRouter>,
     );
-    expect(screen.getByRole("button", { name: /hiking/i })).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /hiking/i })).toBeInTheDocument(),
+    );
   });
 
-  it("renders an 'I'm interested' button on each card", () => {
+  it("renders an 'I'm interested' button on each card", async () => {
+    mockSuccess();
     render(
       <MemoryRouter>
         <DiscoveryPage isLinked={true} />
       </MemoryRouter>,
     );
-    const buttons = screen.getAllByRole("button", { name: /i'm interested/i });
-    expect(buttons.length).toBeGreaterThan(0);
+
+    await waitFor(() =>
+      expect(
+        screen.getAllByRole("button", { name: /i'm interested/i }).length,
+      ).toBeGreaterThan(0),
+    );
   });
 
   // FR-DISC-05 / US-08: unlinked state
@@ -69,25 +153,79 @@ describe("DiscoveryPage", () => {
     expect(
       screen.queryAllByRole("button", { name: /i'm interested/i }),
     ).toHaveLength(0);
+    expect(mockApiFetch).not.toHaveBeenCalled();
   });
 
-  // FR-DISC-04: incomplete couples excluded
-  it("excludes incomplete couples from the feed", () => {
+  // FR-DISC-04 / FR-DISC-06: server handles exclusions; frontend renders only what API returns
+  it("excludes incomplete couples — server filters before responding", async () => {
+    mockSuccess();
     render(
       <MemoryRouter>
         <DiscoveryPage isLinked={true} />
       </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
     );
     expect(screen.queryByText(/incomplete couple/i)).not.toBeInTheDocument();
   });
 
-  // FR-DISC-06: already-connected couples excluded
-  it("excludes already-connected couples from the feed", () => {
+  it("excludes already-connected couples — server filters before responding", async () => {
+    mockSuccess();
     render(
       <MemoryRouter>
         <DiscoveryPage isLinked={true} />
       </MemoryRouter>,
     );
+
+    await waitFor(() =>
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
+    );
     expect(screen.queryByText(/already connected/i)).not.toBeInTheDocument();
+  });
+
+  it("shows an error message when the API call fails", async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: "Failed to load discovery feed" }),
+    });
+
+    render(
+      <MemoryRouter>
+        <DiscoveryPage isLinked={true} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/failed to load discovery feed/i),
+      ).toBeInTheDocument(),
+    );
+  });
+
+  it("modal shows per-partner cards with name, bio, and location", async () => {
+    mockSuccess();
+    render(
+      <MemoryRouter>
+        <DiscoveryPage isLinked={true} />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
+    );
+
+    // Click the first couple card to open the modal
+    const cards = screen.getAllByRole("button", { name: /i'm interested/i });
+    await userEvent.click(cards[0].closest(".couple-card")!);
+
+    // Per-partner section header
+    expect(screen.getByRole("heading", { name: /partners/i })).toBeInTheDocument();
+    // Partner names appear in the partner cards
+    expect(screen.getAllByText("Morgan").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Casey").length).toBeGreaterThan(0);
+    // Partner bio
+    expect(screen.getByText("I love the mountains.")).toBeInTheDocument();
   });
 });

--- a/client/src/pages/DiscoveryPage.tsx
+++ b/client/src/pages/DiscoveryPage.tsx
@@ -1,104 +1,82 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { CoupleCard, AvatarPair } from "../components/CoupleCard";
 import type { Couple } from "../components/CoupleCard";
+import { apiFetch } from "../lib/api";
 
-// Tags normalized: lowercase + trim (FR-TAG-03)
-const PLACEHOLDER_COUPLES: Couple[] = [
-  {
-    id: 1,
-    names: "Morgan & Casey",
-    initials1: "MH",
-    initials2: "CT",
-    inCommon: 5,
-    interests: ["hiking", "cycling", "running", "yoga", "films"],
-    matching: ["hiking", "cycling", "films"],
-    description:
-      "Active couple who can't sit still! We're training for our third marathon together and love staying fit. Also huge film nerds on our rest days.",
-    location: "Denver, CO",
-    complete: true,
-    connected: false,
-  },
-  {
-    id: 2,
-    names: "Alex & Jordan",
-    initials1: "AK",
-    initials2: "JL",
-    inCommon: 4,
-    interests: ["hiking", "board games", "cooking", "wine"],
-    matching: ["hiking", "board games", "cooking"],
-    description:
-      "We're outdoor enthusiasts who love game nights! Always looking for new trails to explore and new recipes to try.",
-    location: "Portland, OR",
-    complete: true,
-    connected: false,
-  },
-  {
-    id: 3,
-    names: "Parker & Quinn",
-    initials1: "PR",
-    initials2: "QN",
-    inCommon: 4,
-    interests: ["cycling", "running", "yoga", "cooking"],
-    matching: ["cycling", "cooking"],
-    description:
-      "Health-conscious foodies! We bike to the farmers market every weekend and love experimenting with plant-based recipes.",
-    location: "Boulder, CO",
-    complete: true,
-    connected: false,
-  },
-  {
-    id: 4,
-    names: "Sam & Riley",
-    initials1: "SM",
-    initials2: "RW",
-    inCommon: 3,
-    interests: ["films", "yoga", "travel", "cooking"],
-    matching: ["films", "cooking"],
-    description:
-      "Movie buffs and yoga practitioners. We love hosting dinner parties and discussing the latest films.",
-    location: "Austin, TX",
-    complete: true,
-    connected: false,
-  },
-  {
-    id: 5,
-    names: "Drew & Avery",
-    initials1: "DP",
-    initials2: "AM",
-    inCommon: 3,
-    interests: ["travel", "hiking", "films", "wine"],
-    matching: ["hiking", "films"],
-    description:
-      "Travel addicts who've visited 30 countries together. We love sharing stories over wine and finding hidden hiking gems.",
-    location: "San Francisco, CA",
-    complete: true,
-    connected: false,
-  },
-  {
-    id: 6,
-    names: "Taylor & Jamie",
-    initials1: "TS",
-    initials2: "JB",
-    inCommon: 2,
-    interests: ["board games", "trivia", "wine", "cooking"],
-    matching: ["board games", "cooking"],
-    description:
-      "Competitive trivia team looking for worthy opponents! We host monthly game nights and love exploring the local wine scene.",
-    location: "Seattle, WA",
-    complete: true,
-    connected: false,
-  },
-];
+interface PartnerDetail {
+  display_name: string;
+  about_me: string | null;
+  location: string | null;
+  tags: string[];
+}
 
-const ALL_FILTERS = ["hiking", "board games", "cooking", "films", "cycling"];
+interface DiscoveryResult {
+  pair_id: string;
+  about_us: string | null;
+  location: string | null;
+  tags: string[];
+  matching_tags: string[];
+  shared_count: number;
+  partner1: PartnerDetail;
+  partner2: PartnerDetail;
+}
+
+function getInitials(name: string): string {
+  const words = name.trim().split(/\s+/);
+  if (words.length >= 2) {
+    return ((words[0]?.[0] ?? "") + (words[1]?.[0] ?? "")).toUpperCase();
+  }
+  return name.slice(0, 2).toUpperCase();
+}
+
+function toCouple(r: DiscoveryResult): Couple {
+  return {
+    id: r.pair_id,
+    names: `${r.partner1.display_name} & ${r.partner2.display_name}`,
+    initials1: getInitials(r.partner1.display_name),
+    initials2: getInitials(r.partner2.display_name),
+    inCommon: r.shared_count,
+    interests: r.tags,
+    matching: r.matching_tags,
+    description: r.about_us ?? "",
+    location: r.location ?? "",
+  };
+}
 
 interface Props {
   isLinked: boolean;
 }
 
 export default function DiscoveryPage({ isLinked }: Props) {
+  const [results, setResults] = useState<DiscoveryResult[]>([]);
+  const [couples, setCouples] = useState<Couple[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [activeFilters, setActiveFilters] = useState<string[]>([]);
-  const [selectedCouple, setSelectedCouple] = useState<number | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isLinked) {
+      setLoading(false);
+      return;
+    }
+
+    apiFetch("/discovery")
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = (await res.json()) as { error?: string };
+          setError(body.error ?? "Failed to load discovery feed");
+          return;
+        }
+        const data = (await res.json()) as DiscoveryResult[];
+        setResults(data);
+        setCouples(data.map(toCouple));
+      })
+      .catch(() => setError("Failed to load discovery feed"))
+      .finally(() => setLoading(false));
+  }, [isLinked]);
+
+  const allTags = [...new Set(couples.flatMap((c) => c.interests))];
 
   const toggleFilter = (tag: string) => {
     setActiveFilters((prev) =>
@@ -106,19 +84,19 @@ export default function DiscoveryPage({ isLinked }: Props) {
     );
   };
 
-  // FR-DISC-04: exclude own couple (handled server-side; placeholder has no "own" entry)
-  // FR-DISC-06: exclude already-connected couples
-  // FR-DISC-05: exclude incomplete couples
-  const eligibleCouples = PLACEHOLDER_COUPLES.filter(
-    (c) => c.complete && !c.connected,
-  ).sort((a, b) => b.inCommon - a.inCommon);
-
   const visibleCouples =
     activeFilters.length === 0
-      ? eligibleCouples
-      : eligibleCouples.filter((c) =>
+      ? couples
+      : couples.filter((c) =>
           activeFilters.some((f) => c.interests.includes(f)),
         );
+
+  const selectedResult = selectedId
+    ? results.find((r) => r.pair_id === selectedId) ?? null
+    : null;
+  const selectedCouple = selectedId
+    ? visibleCouples.find((c) => c.id === selectedId) ?? null
+    : null;
 
   return (
     <div className="discovery-page">
@@ -137,94 +115,149 @@ export default function DiscoveryPage({ isLinked }: Props) {
             </p>
           </div>
         </div>
+      ) : loading ? (
+        <p className="discovery-subtitle">Loading…</p>
+      ) : error ? (
+        <p className="discovery-subtitle">{error}</p>
       ) : (
         <>
-          <div className="filter-pills">
-            {ALL_FILTERS.map((tag) => (
-              <button
-                key={tag}
-                className={`pill${activeFilters.includes(tag) ? " pill--active" : ""}`}
-                onClick={() => toggleFilter(tag)}
-              >
-                {tag}
-              </button>
-            ))}
-          </div>
+          {allTags.length > 0 && (
+            <div className="filter-pills">
+              {allTags.map((tag) => (
+                <button
+                  key={tag}
+                  className={`pill${activeFilters.includes(tag) ? " pill--active" : ""}`}
+                  onClick={() => toggleFilter(tag)}
+                >
+                  {tag}
+                </button>
+              ))}
+            </div>
+          )}
 
           <div className="couple-grid">
             {visibleCouples.map((couple) => (
               <CoupleCard
                 key={couple.id}
                 couple={couple}
-                onClick={() => setSelectedCouple(couple.id)}
+                onClick={() => setSelectedId(couple.id)}
                 onInterested={() => {}}
               />
             ))}
           </div>
 
-          {selectedCouple !== null && (
+          {selectedResult && selectedCouple && (
             <div
               className="discovery-modal-overlay"
-              onClick={() => setSelectedCouple(null)}
+              onClick={() => setSelectedId(null)}
             >
               <div
                 className="discovery-modal"
                 onClick={(e) => e.stopPropagation()}
               >
-                {(() => {
-                  const couple = visibleCouples.find(
-                    (c) => c.id === selectedCouple,
-                  );
-                  if (!couple) return null;
-                  return (
-                    <>
-                      <div className="discovery-modal-header">
-                        <div className="couple-card-identity">
-                          <AvatarPair
-                            initials1={couple.initials1}
-                            initials2={couple.initials2}
-                            size="lg"
-                          />
-                          <div>
-                            <h2>{couple.names}</h2>
-                            <p className="discovery-subtitle">
-                              {couple.location}
-                            </p>
-                          </div>
-                        </div>
-                        <button
-                          className="discovery-modal-close"
-                          onClick={() => setSelectedCouple(null)}
+                {/* Header */}
+                <div className="discovery-modal-header">
+                  <div className="couple-card-identity">
+                    <AvatarPair
+                      initials1={selectedCouple.initials1}
+                      initials2={selectedCouple.initials2}
+                      size="lg"
+                    />
+                    <div>
+                      <h2>{selectedCouple.names}</h2>
+                      {selectedResult.location && (
+                        <p className="discovery-subtitle">
+                          {selectedResult.location}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                  <button
+                    className="discovery-modal-close"
+                    onClick={() => setSelectedId(null)}
+                  >
+                    ×
+                  </button>
+                </div>
+
+                {/* About us */}
+                {selectedResult.about_us && (
+                  <div className="discovery-modal-section">
+                    <h3>About us</h3>
+                    <p className="text-muted">{selectedResult.about_us}</p>
+                  </div>
+                )}
+
+                {/* Shared interests */}
+                {selectedResult.tags.length > 0 && (
+                  <div className="discovery-modal-section">
+                    <h3>Interests</h3>
+                    <div className="discovery-modal-common">
+                      <span>
+                        {selectedResult.shared_count} interest
+                        {selectedResult.shared_count === 1 ? "" : "s"} in common
+                      </span>
+                    </div>
+                    <div className="interest-pills">
+                      {selectedResult.tags.map((tag) => (
+                        <span
+                          key={tag}
+                          className={`pill pill--sm${selectedResult.matching_tags.includes(tag) ? " pill--active" : ""}`}
                         >
-                          ×
-                        </button>
-                      </div>
-                      <div className="discovery-modal-section">
-                        <h3>About us</h3>
-                        <p className="text-muted">{couple.description}</p>
-                      </div>
-                      <div className="discovery-modal-section">
-                        <h3>Interests</h3>
-                        <div className="interest-pills">
-                          {couple.interests.map((interest) => (
-                            <span
-                              key={interest}
-                              className={`pill pill--sm${couple.matching.includes(interest) ? " pill--active" : ""}`}
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {/* Per-partner cards — mirrors CoupleProfilePage */}
+                <div className="discovery-modal-section">
+                  <h3>Partners</h3>
+                  <div className="couple-grid">
+                    {[selectedResult.partner1, selectedResult.partner2].map(
+                      (partner) => (
+                        <div
+                          key={partner.display_name}
+                          className="couple-card couple-card--static"
+                        >
+                          <div className="couple-card-header">
+                            <div className="couple-card-identity">
+                              <div className="avatar avatar--md">
+                                {getInitials(partner.display_name)}
+                              </div>
+                              <span className="couple-names">
+                                {partner.display_name}
+                              </span>
+                            </div>
+                          </div>
+                          <p className="discovery-subtitle">
+                            {partner.location ?? "No location set"}
+                          </p>
+                          <p className="text-muted">
+                            {partner.about_me ?? "No bio yet"}
+                          </p>
+                          {partner.tags.length > 0 && (
+                            <div
+                              className="interest-pills"
+                              style={{ marginTop: 12 }}
                             >
-                              {interest}
-                            </span>
-                          ))}
+                              {partner.tags.map((tag) => (
+                                <span key={tag} className="pill pill--sm">
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
+                          )}
                         </div>
-                      </div>
-                      <div className="discovery-modal-common">
-                        <span>{couple.inCommon} interests in common</span>
-                      </div>
-                      <button className="btn btn--primary btn--full">
-                        {`I'm interested`}
-                      </button>
-                    </>
-                  );
-                })()}
+                      ),
+                    )}
+                  </div>
+                </div>
+
+                <button className="btn btn--primary btn--full">
+                  {`I'm interested`}
+                </button>
               </div>
             </div>
           )}

--- a/client/src/pages/DiscoveryPage.tsx
+++ b/client/src/pages/DiscoveryPage.tsx
@@ -50,14 +50,13 @@ interface Props {
 export default function DiscoveryPage({ isLinked }: Props) {
   const [results, setResults] = useState<DiscoveryResult[]>([]);
   const [couples, setCouples] = useState<Couple[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(isLinked);
   const [error, setError] = useState<string | null>(null);
   const [activeFilters, setActiveFilters] = useState<string[]>([]);
   const [selectedId, setSelectedId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isLinked) {
-      setLoading(false);
       return;
     }
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -2,6 +2,7 @@ import express from "express";
 import cors from "cors";
 import { authRouter } from "./routes/auth.js";
 import { couplesRouter } from "./routes/couples.js";
+import { discoveryRouter } from "./routes/discovery.js";
 import { pairsRouter } from "./routes/pairs.js";
 import { profilesRouter } from "./routes/profiles.js";
 import { usersRouter } from "./routes/users.js";
@@ -19,6 +20,7 @@ app.get("/health", (_, res) => {
 
 app.use("/auth", authRouter);
 app.use("/couples", couplesRouter);
+app.use("/discovery", discoveryRouter);
 app.use("/pairs", pairsRouter);
 app.use("/profiles", profilesRouter);
 app.use("/users", usersRouter);

--- a/server/src/routes/discovery.test.ts
+++ b/server/src/routes/discovery.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+
+vi.mock("../lib/supabase.js", () => {
+  const mockSupabase = {
+    auth: { getUser: vi.fn() },
+    from: vi.fn(),
+    rpc: vi.fn(),
+  };
+  return { supabase: mockSupabase };
+});
+
+const { supabase } = await import("../lib/supabase.js");
+const { app } = await import("../app.js");
+
+const mockAuth = supabase.auth as unknown as {
+  getUser: ReturnType<typeof vi.fn>;
+};
+const mockFrom = supabase.from as ReturnType<typeof vi.fn>;
+
+const MY_ID = "user-me";
+const PARTNER_ID = "user-partner";
+const MY_PAIR_ID = "pair-mine";
+
+const OTHER_PAIR_ID = "pair-other";
+const OTHER_USER_A = "user-other-a";
+const OTHER_USER_B = "user-other-b";
+
+function mockAuthUser(userId = MY_ID) {
+  mockAuth.getUser.mockResolvedValue({
+    data: { user: { id: userId } },
+    error: null,
+  });
+}
+
+type FromCall = {
+  profiles?: object | null;
+  myPair?: object | null;
+  myTags?: object[];
+  connectedRequests?: object[];
+  allPairs?: object[];
+  candidateProfiles?: object[];
+  candidateTags?: object[];
+};
+
+function setupMocks({
+  profiles = { partner_id: PARTNER_ID },
+  myPair = { id: MY_PAIR_ID },
+  myTags = [
+    { tags: { label: "hiking" } },
+    { tags: { label: "cooking" } },
+    { tags: { label: "yoga" } },
+  ],
+  connectedRequests = [],
+  allPairs = [
+    {
+      id: OTHER_PAIR_ID,
+      about_us: "We love the outdoors",
+      location: "Denver, CO",
+      profile_id_1: OTHER_USER_A,
+      profile_id_2: OTHER_USER_B,
+    },
+  ],
+  candidateProfiles = [
+    { id: OTHER_USER_A, display_name: "Alex", about_me: "Love hiking", location: "Denver, CO" },
+    { id: OTHER_USER_B, display_name: "Jordan", about_me: "Love cooking", location: "Portland, OR" },
+  ],
+  candidateTags = [
+    { user_id: OTHER_USER_A, tags: { label: "hiking" } },
+    { user_id: OTHER_USER_A, tags: { label: "films" } },
+    { user_id: OTHER_USER_B, tags: { label: "cooking" } },
+  ],
+}: FromCall = {}) {
+  let profileCallCount = 0;
+  let pairsCallCount = 0;
+  let userTagsCallCount = 0;
+
+  mockFrom.mockImplementation((table: string) => {
+    if (table === "profiles") {
+      profileCallCount++;
+      // 1st call: my profile (partner_id check)
+      if (profileCallCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              single: vi
+                .fn()
+                .mockResolvedValue({ data: profiles, error: profiles ? null : { message: "Not found" } }),
+            }),
+          }),
+        };
+      }
+      // 2nd call: batch profile fetch for candidates
+      return {
+        select: vi.fn().mockReturnValue({
+          in: vi.fn().mockResolvedValue({ data: candidateProfiles, error: null }),
+        }),
+      };
+    }
+
+    if (table === "pairs") {
+      pairsCallCount++;
+      // 1st call: my pair (single)
+      if (pairsCallCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            or: vi.fn().mockReturnValue({
+              single: vi
+                .fn()
+                .mockResolvedValue({ data: myPair, error: myPair ? null : { message: "Not found" } }),
+            }),
+          }),
+        };
+      }
+      // 2nd call: all other pairs
+      return {
+        select: vi.fn().mockReturnValue({
+          neq: vi.fn().mockResolvedValue({ data: allPairs, error: null }),
+        }),
+      };
+    }
+
+    if (table === "user_tags") {
+      userTagsCallCount++;
+      // 1st call: my couple's tags
+      if (userTagsCallCount === 1) {
+        return {
+          select: vi.fn().mockReturnValue({
+            in: vi.fn().mockResolvedValue({ data: myTags, error: null }),
+          }),
+        };
+      }
+      // 2nd call: candidate tags
+      return {
+        select: vi.fn().mockReturnValue({
+          in: vi.fn().mockResolvedValue({ data: candidateTags, error: null }),
+        }),
+      };
+    }
+
+    if (table === "connection_requests") {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            or: vi.fn().mockResolvedValue({ data: connectedRequests, error: null }),
+          }),
+        }),
+      };
+    }
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("GET /discovery", () => {
+  it("returns 403 when user is not paired", async () => {
+    mockAuthUser();
+    setupMocks({ profiles: { partner_id: null } });
+
+    const res = await request(app)
+      .get("/discovery")
+      .set("Authorization", "Bearer valid-jwt");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toMatch(/linked with a partner/i);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockAuth.getUser.mockResolvedValue({ data: { user: null }, error: { message: "Unauthorized" } });
+
+    const res = await request(app).get("/discovery");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 with ranked results sorted by shared tag count descending", async () => {
+    mockAuthUser();
+    setupMocks({
+      allPairs: [
+        { id: "pair-a", about_us: null, location: "NYC", profile_id_1: "ua1", profile_id_2: "ua2" },
+        { id: "pair-b", about_us: null, location: "LA", profile_id_1: "ub1", profile_id_2: "ub2" },
+      ],
+      candidateProfiles: [
+        { id: "ua1", display_name: "Alice", about_me: null, location: null },
+        { id: "ua2", display_name: "Bob", about_me: null, location: null },
+        { id: "ub1", display_name: "Carol", about_me: null, location: null },
+        { id: "ub2", display_name: "Dan", about_me: null, location: null },
+      ],
+      candidateTags: [
+        // pair-a: shares hiking + cooking with us (2 in common)
+        { user_id: "ua1", tags: { label: "hiking" } },
+        { user_id: "ua2", tags: { label: "cooking" } },
+        // pair-b: shares only yoga (1 in common)
+        { user_id: "ub1", tags: { label: "yoga" } },
+        { user_id: "ub2", tags: { label: "films" } },
+      ],
+    });
+
+    const res = await request(app)
+      .get("/discovery")
+      .set("Authorization", "Bearer valid-jwt");
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0].shared_count).toBeGreaterThanOrEqual(res.body[1].shared_count);
+    expect(res.body[0].pair_id).toBe("pair-a");
+  });
+
+  it("excludes own couple from results", async () => {
+    mockAuthUser();
+    // allPairs query uses .neq("id", myPair.id) so own pair is excluded at DB level.
+    // We verify it's not in the response.
+    setupMocks({
+      allPairs: [], // DB already excluded own pair
+    });
+
+    const res = await request(app)
+      .get("/discovery")
+      .set("Authorization", "Bearer valid-jwt");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("excludes already-connected couples from results", async () => {
+    mockAuthUser();
+    setupMocks({
+      connectedRequests: [
+        {
+          couple_1_user_a: MY_ID,
+          couple_1_user_b: PARTNER_ID,
+          couple_2_user_a: OTHER_USER_A,
+          couple_2_user_b: OTHER_USER_B,
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .get("/discovery")
+      .set("Authorization", "Bearer valid-jwt");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("excludes incomplete couples (missing profile for a partner)", async () => {
+    mockAuthUser();
+    setupMocks({
+      candidateProfiles: [
+        { id: OTHER_USER_A, display_name: "Alex" },
+        // OTHER_USER_B is missing — incomplete couple
+      ],
+    });
+
+    const res = await request(app)
+      .get("/discovery")
+      .set("Authorization", "Bearer valid-jwt");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("returns correct fields in each result", async () => {
+    mockAuthUser();
+    setupMocks();
+
+    const res = await request(app)
+      .get("/discovery")
+      .set("Authorization", "Bearer valid-jwt");
+
+    expect(res.status).toBe(200);
+    expect(res.body.length).toBe(1);
+    const item = res.body[0];
+    expect(item).toHaveProperty("pair_id");
+    expect(item).toHaveProperty("about_us");
+    expect(item).toHaveProperty("location");
+    expect(item).toHaveProperty("tags");
+    expect(item).toHaveProperty("matching_tags");
+    expect(item).toHaveProperty("shared_count");
+    expect(item).toHaveProperty("partner1.display_name");
+    expect(item).toHaveProperty("partner1.about_me");
+    expect(item).toHaveProperty("partner1.location");
+    expect(item).toHaveProperty("partner1.tags");
+    expect(item).toHaveProperty("partner2.display_name");
+    expect(item).toHaveProperty("partner2.about_me");
+    expect(item).toHaveProperty("partner2.location");
+    expect(item).toHaveProperty("partner2.tags");
+  });
+
+  it("returns matching_tags as intersection of couples' tags", async () => {
+    mockAuthUser();
+    // My tags: hiking, cooking, yoga
+    // Other couple tags: hiking, films, cooking → matching: hiking, cooking
+    setupMocks();
+
+    const res = await request(app)
+      .get("/discovery")
+      .set("Authorization", "Bearer valid-jwt");
+
+    expect(res.status).toBe(200);
+    expect(res.body[0].matching_tags).toEqual(expect.arrayContaining(["hiking", "cooking"]));
+    expect(res.body[0].shared_count).toBe(2);
+  });
+
+  it("returns empty array when no eligible couples exist", async () => {
+    mockAuthUser();
+    setupMocks({ allPairs: [] });
+
+    const res = await request(app)
+      .get("/discovery")
+      .set("Authorization", "Bearer valid-jwt");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+});

--- a/server/src/routes/discovery.ts
+++ b/server/src/routes/discovery.ts
@@ -1,0 +1,213 @@
+import { Router } from "express";
+import type { Request, Response } from "express";
+import { supabase } from "../lib/supabase.js";
+import { verifyToken } from "../middleware/auth.js";
+
+export const discoveryRouter = Router();
+
+// GET /discovery
+// Returns couples ranked by shared tag count with the requesting couple.
+// Excludes: own couple, incomplete couples, already-connected couples.
+// Requires the requesting user to be linked with a partner (403 otherwise).
+discoveryRouter.get("/", verifyToken, async (_req: Request, res: Response) => {
+  const user = res.locals["user"] as { id: string };
+
+  // 1. Verify user is paired
+  const { data: myProfile } = await supabase
+    .from("profiles")
+    .select("partner_id")
+    .eq("id", user.id)
+    .single();
+
+  if (!myProfile || myProfile.partner_id == null) {
+    res
+      .status(403)
+      .json({ error: "You must be linked with a partner to browse discovery" });
+    return;
+  }
+
+  const partnerId = myProfile.partner_id as string;
+
+  // 2. Get my pair row
+  const { data: myPair } = await supabase
+    .from("pairs")
+    .select("id")
+    .or(`profile_id_1.eq.${user.id},profile_id_2.eq.${user.id}`)
+    .single();
+
+  if (!myPair) {
+    res.status(404).json({ error: "Couple profile not found" });
+    return;
+  }
+
+  // 3. Get my couple's union of tags
+  const { data: myTagRows, error: myTagsError } = await supabase
+    .from("user_tags")
+    .select("tags(label)")
+    .in("user_id", [user.id, partnerId]);
+
+  if (myTagsError) {
+    res.status(500).json({ error: "Failed to fetch tags" });
+    return;
+  }
+
+  const myTags = new Set(
+    (
+      (myTagRows ?? []) as unknown as {
+        tags: { label: string } | null;
+      }[]
+    )
+      .map((r) => r.tags?.label)
+      .filter((l): l is string => typeof l === "string"),
+  );
+
+  // 4. Find all CONNECTED connection requests involving our couple to exclude
+  const { data: connectedRequests } = await supabase
+    .from("connection_requests")
+    .select(
+      "couple_1_user_a, couple_1_user_b, couple_2_user_a, couple_2_user_b",
+    )
+    .eq("status", "CONNECTED")
+    .or(
+      `couple_1_user_a.eq.${user.id},couple_1_user_b.eq.${user.id},couple_2_user_a.eq.${user.id},couple_2_user_b.eq.${user.id}`,
+    );
+
+  const connectedUserIds = new Set<string>();
+  const myIds = new Set([user.id, partnerId]);
+  for (const req of connectedRequests ?? []) {
+    const c1 = [
+      req.couple_1_user_a as string,
+      req.couple_1_user_b as string,
+    ];
+    const c2 = [
+      req.couple_2_user_a as string,
+      req.couple_2_user_b as string,
+    ];
+    if (c1.some((id) => myIds.has(id))) {
+      c2.forEach((id) => connectedUserIds.add(id));
+    } else {
+      c1.forEach((id) => connectedUserIds.add(id));
+    }
+  }
+
+  // 5. Fetch all other pairs
+  const { data: allPairs, error: pairsError } = await supabase
+    .from("pairs")
+    .select("id, about_us, location, profile_id_1, profile_id_2")
+    .neq("id", myPair.id as string);
+
+  if (pairsError) {
+    res.status(500).json({ error: "Failed to fetch discovery feed" });
+    return;
+  }
+
+  if (!allPairs || allPairs.length === 0) {
+    res.status(200).json([]);
+    return;
+  }
+
+  // 6. Filter out already-connected couples
+  const eligiblePairs = allPairs.filter((pair) => {
+    const p1 = pair.profile_id_1 as string;
+    const p2 = pair.profile_id_2 as string;
+    return !connectedUserIds.has(p1) && !connectedUserIds.has(p2);
+  });
+
+  if (eligiblePairs.length === 0) {
+    res.status(200).json([]);
+    return;
+  }
+
+  // 7. Batch-fetch profiles and tags for all candidate users
+  const candidateUserIds = eligiblePairs.flatMap((p) => [
+    p.profile_id_1 as string,
+    p.profile_id_2 as string,
+  ]);
+
+  const [{ data: profiles }, { data: tagRows }] = await Promise.all([
+    supabase
+      .from("profiles")
+      .select("id, display_name, about_me, location")
+      .in("id", candidateUserIds),
+    supabase
+      .from("user_tags")
+      .select("user_id, tags(label)")
+      .in("user_id", candidateUserIds),
+  ]);
+
+  type ProfileRow = {
+    id: string;
+    display_name: string;
+    about_me: string | null;
+    location: string | null;
+  };
+
+  const profileMap = new Map<string, ProfileRow>(
+    (profiles ?? []).map((p) => [
+      p.id as string,
+      {
+        id: p.id as string,
+        display_name: p.display_name as string,
+        about_me: (p.about_me as string | null) ?? null,
+        location: (p.location as string | null) ?? null,
+      },
+    ]),
+  );
+
+  const tagsByUser = new Map<string, string[]>();
+  for (const row of (tagRows ?? []) as unknown as {
+    user_id: string;
+    tags: { label: string } | null;
+  }[]) {
+    if (!row.tags?.label) continue;
+    const label = row.tags.label;
+    const existing = tagsByUser.get(row.user_id);
+    if (existing) {
+      existing.push(label);
+    } else {
+      tagsByUser.set(row.user_id, [label]);
+    }
+  }
+
+  // 8. Build results — exclude incomplete couples (missing profile for either partner)
+  const results = eligiblePairs
+    .filter(
+      (pair) =>
+        profileMap.has(pair.profile_id_1 as string) &&
+        profileMap.has(pair.profile_id_2 as string),
+    )
+    .map((pair) => {
+      const p1Id = pair.profile_id_1 as string;
+      const p2Id = pair.profile_id_2 as string;
+      const p1 = profileMap.get(p1Id)!;
+      const p2 = profileMap.get(p2Id)!;
+      const p1Tags = tagsByUser.get(p1Id) ?? [];
+      const p2Tags = tagsByUser.get(p2Id) ?? [];
+      const allPairTags = [...new Set([...p1Tags, ...p2Tags])];
+      const matchingTags = allPairTags.filter((t) => myTags.has(t));
+
+      return {
+        pair_id: pair.id as string,
+        about_us: (pair.about_us as string | null) ?? null,
+        location: (pair.location as string | null) ?? null,
+        tags: allPairTags,
+        matching_tags: matchingTags,
+        shared_count: matchingTags.length,
+        partner1: {
+          display_name: p1.display_name,
+          about_me: p1.about_me,
+          location: p1.location,
+          tags: p1Tags,
+        },
+        partner2: {
+          display_name: p2.display_name,
+          about_me: p2.about_me,
+          location: p2.location,
+          tags: p2Tags,
+        },
+      };
+    })
+    .sort((a, b) => b.shared_count - a.shared_count);
+
+  res.status(200).json(results);
+});


### PR DESCRIPTION
- GET /discovery endpoint: returns couples ranked by shared tag count, excludes own couple, incomplete couples, and already-connected couples; returns per-partner detail (display_name, about_me, location, tags)
- DiscoveryPage wired to real API replacing placeholder data; filter pills derived from live tags; loading/error states
- Discovery modal redesigned to match couple profile preview: per-partner cards showing individual bio, location, and tags; shared count placed under Interests heading with correct pluralization
- 9 server tests + 10 client tests; all 86 tests pass
- 
<img width="1215" height="530" alt="Screenshot 2026-04-13 at 3 35 30 PM" src="https://github.com/user-attachments/assets/ce16d1ab-3203-4612-a5d5-fe8daa78f74e" />

<img width="660" height="703" alt="Screenshot 2026-04-13 at 3 33 52 PM" src="https://github.com/user-attachments/assets/04994825-8e7d-4a7e-b43a-7dad54eec64b" />

<img width="657" height="687" alt="Screenshot 2026-04-13 at 3 34 05 PM" src="https://github.com/user-attachments/assets/6af717c0-1014-40fb-b3c0-4478341588c8" />
